### PR TITLE
Fix invalid SQL join in Fleet query

### DIFF
--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -2275,7 +2275,7 @@ spec:
   name: Get Docker contained processes on a system
   platform: darwin, linux
   description: Docker containers Processes, can be used on normal systems or a kubenode.
-  query: SELECT c.id, c.name, c.image, c.image_id, c.command, c.created, c.state, c.status, p.cmdline  FROM docker_containers c CROSS JOIN docker_container_processes p using(id);
+  query: SELECT c.id, c.name, c.image, c.image_id, c.command, c.created, c.state, c.status, p.cmdline  FROM docker_containers c JOIN docker_container_processes p ON c.id = p.id;
   bash: echo "id,name,image,image_id,command,created,state,status,cmdline"; for id in $(docker ps -q); do cont=$(docker inspect --format='{{.Id}},{{.Name}},{{.Config.Image}},{{.Image}},{{.Path}} {{range .Args}}{{.}} {{end}},{{.Created}},{{.State.Status}},{{.State.ExitCode}}' "$id"); docker top "$id" aux | sed '1d' | while IFS= read -r proc; do echo "$cont,\"$proc\""; done; done
   purpose: Informational
   tags: built-in, containers, inventory


### PR DESCRIPTION
The existing query used a CROSS JOIN with USING(id), which is not valid SQL in Fleet/SQLite and resulted in a syntax error when saving the query.

This change replaces the CROSS JOIN with a standard JOIN ... ON ... clause. The explicit ON form was chosen for clarity:

- Makes the join condition (c.id = p.id) obvious to readers
- Avoids the subtle column-merging behavior of USING(id)

This preserves the intended behavior (joining containers with their processes by ID) while ensuring the query can be saved and run correctly in Fleet.